### PR TITLE
Add launcher=posix option to mesos-slave

### DIFF
--- a/cluster/Vagrantfile
+++ b/cluster/Vagrantfile
@@ -30,7 +30,8 @@ end
 slaves.map do |n|
   n[:attributes] = { mesos: { slave: { flags: {
     ip: n[:ip],
-    master: masters.map { |m| "#{m[:ip]}:5050" }.join(',')
+    master: masters.map { |m| "#{m[:ip]}:5050" }.join(','),
+    launcher: 'posix',
   } } } }
 end
 # Sum up all nodes


### PR DESCRIPTION
For mesos-slave to be able to start in a LXC context that do not provide cgroups isolation